### PR TITLE
Added option to connect using IP address of the robot.

### DIFF
--- a/unitree_sdk2py/core/channel.py
+++ b/unitree_sdk2py/core/channel.py
@@ -13,7 +13,7 @@ from cyclonedds.util import duration
 from cyclonedds.internal import dds_c_t, InvalidSample
 
 # for channel config
-from .channel_config import ChannelConfigAutoDetermine, ChannelConfigHasInterface
+from .channel_config import ChannelConfigAutoDetermine, ChannelConfigHasInterface, ChannelConfigHasIP
 
 # for singleton
 from ..utils.singleton import Singleton
@@ -201,7 +201,12 @@ class ChannelFactory(Singleton):
         if networkInterface is None:
             config = ChannelConfigAutoDetermine
         else:
-            config = ChannelConfigHasInterface.replace('$__IF_NAME__$', networkInterface)
+            if "." in networkInterface: # connect using IP
+                config = ChannelConfigHasIP.replace('$__IF_IP__$', networkInterface)
+                print(f"connecting using IP: {networkInterface}")
+            else: # connect using Iface
+                config = ChannelConfigHasInterface.replace('$__IF_NAME__$', networkInterface)
+                print(f"connecting using Iface: {networkInterface}")
 
         try:
             self.__domain = Domain(id, config)

--- a/unitree_sdk2py/core/channel_config.py
+++ b/unitree_sdk2py/core/channel_config.py
@@ -23,3 +23,14 @@ ChannelConfigAutoDetermine = '''<?xml version="1.0" encoding="UTF-8" ?>
             </General>
         </Domain>
     </CycloneDDS>'''
+
+ChannelConfigHasIP = '''<?xml version="1.0" encoding="UTF-8" ?>
+    <CycloneDDS>
+        <Domain Id="any">
+            <General>
+                <Interfaces>
+                    <NetworkInterface address="$__IF_IP__$" priority="default" multicast="default"/>
+                </Interfaces>
+            </General>
+        </Domain>
+    </CycloneDDS>'''


### PR DESCRIPTION
Added option to connect using IP address of the robot.

For Example:
```
python3 ./example/front_camera/camera_opencv.py enp2s0
```
```
python3 ./example/front_camera/camera_opencv.py 192.168.123.51
```
Both of the above will work, where "192.168.123.51" is the static IP address of the robot.