### PR TITLE
Update ChannelFactoryInitialize to use sys.argv[1]

### DIFF
--- a/example/high_level/read_highstate.py
+++ b/example/high_level/read_highstate.py
@@ -15,7 +15,10 @@ def HighStateHandler(msg: SportModeState_):
 
 
 if __name__ == "__main__":
-    ChannelFactoryInitialize(0, "enp3s0")
+    if len(sys.argv)>1:
+        ChannelFactoryInitialize(0, sys.argv[1])
+    else:
+        ChannelFactoryInitialize(0)
     sub = ChannelSubscriber("rt/sportmodestate", SportModeState_)
     sub.Init(HighStateHandler, 10)
 


### PR DESCRIPTION
Changed the inputs to the ChannelFactoryInitialize from the default network interface string to dynamic input via sys.argv[1].

This is already implemented and working in other example files.