### PR TITLE
Fixed crc.py to match crc_aarch64.so lib file instead of crc_arm64.so.

### DIFF
--- a/unitree_sdk2py/utils/crc.py
+++ b/unitree_sdk2py/utils/crc.py
@@ -31,7 +31,7 @@ class CRC(Singleton):
             if platform.machine()=="x86_64":
                 self.crc_lib = ctypes.CDLL(script_dir + '/lib/crc_amd64.so')
             elif platform.machine()=="aarch64":
-                self.crc_lib = ctypes.CDLL(script_dir + '/lib/crc_arm64.so')
+                self.crc_lib = ctypes.CDLL(script_dir + '/lib/crc_aarch64.so')
 
             self.crc_lib.crc32_core.argtypes = (ctypes.POINTER(ctypes.c_uint32), ctypes.c_uint32)
             self.crc_lib.crc32_core.restype = ctypes.c_uint32


### PR DESCRIPTION
There was a file name mismatch in line 34. For arm64, the correct file available in the lib folder is crc_aarch64.so.