### PR TITLE
Fix: go2 robot_state_client import incorrect rpc internal module

### DIFF
--- a/unitree_sdk2py/go2/robot_state/robot_state_client.py
+++ b/unitree_sdk2py/go2/robot_state/robot_state_client.py
@@ -1,7 +1,7 @@
 import json
 
 from ...rpc.client import Client
-from ...rpc.client_internal import *
+from ...rpc.internal import *
 from .robot_state_api import *
 
 


### PR DESCRIPTION
Description:
 * go2 robot state client should import internal rather than client_internal