### PR TITLE
Pull-Request: Bring Python SDK (Go2 Edu) in line with Go2 V 1.1.6 high-level interface

### DIFF
--- a/unitree_sdk2py/go2/sport/sport_api.py
+++ b/unitree_sdk2py/go2/sport/sport_api.py
@@ -1,74 +1,84 @@
 """
-" service name
+Service name and API version
 """
 SPORT_SERVICE_NAME = "sport"
+SPORT_API_VERSION  = "1.0.0.1"
 
-
-"""
-" service api version
-"""
-SPORT_API_VERSION = "1.0.0.1"
-
-
-"""
-" api id
-"""
-SPORT_API_ID_DAMP = 1001
-SPORT_API_ID_BALANCESTAND = 1002
-SPORT_API_ID_STOPMOVE = 1003
-SPORT_API_ID_STANDUP = 1004
-SPORT_API_ID_STANDDOWN = 1005
-SPORT_API_ID_RECOVERYSTAND = 1006
-SPORT_API_ID_EULER = 1007
-SPORT_API_ID_MOVE = 1008
-SPORT_API_ID_SIT = 1009
-SPORT_API_ID_RISESIT = 1010
-SPORT_API_ID_SWITCHGAIT = 1011
-SPORT_API_ID_TRIGGER = 1012
-SPORT_API_ID_BODYHEIGHT = 1013
-SPORT_API_ID_FOOTRAISEHEIGHT = 1014
-SPORT_API_ID_SPEEDLEVEL = 1015
-SPORT_API_ID_HELLO = 1016
-SPORT_API_ID_STRETCH = 1017
-SPORT_API_ID_TRAJECTORYFOLLOW = 1018
-SPORT_API_ID_CONTINUOUSGAIT = 1019
-SPORT_API_ID_CONTENT = 1020
-SPORT_API_ID_WALLOW = 1021
-SPORT_API_ID_DANCE1 = 1022
-SPORT_API_ID_DANCE2 = 1023
-SPORT_API_ID_GETBODYHEIGHT = 1024
+# ------------------------------------------------------------------ #
+#  High-level / legacy IDs (kept from ≤ V1.1.5)                       #
+# ------------------------------------------------------------------ #
+SPORT_API_ID_DAMP               = 1001
+SPORT_API_ID_BALANCESTAND       = 1002
+SPORT_API_ID_STOPMOVE           = 1003
+SPORT_API_ID_STANDUP            = 1004
+SPORT_API_ID_STANDDOWN          = 1005
+SPORT_API_ID_RECOVERYSTAND      = 1006
+SPORT_API_ID_EULER              = 1007
+SPORT_API_ID_MOVE               = 1008
+SPORT_API_ID_SIT                = 1009
+SPORT_API_ID_RISESIT            = 1010
+SPORT_API_ID_SWITCHGAIT         = 1011
+SPORT_API_ID_TRIGGER            = 1012
+SPORT_API_ID_BODYHEIGHT         = 1013
+SPORT_API_ID_FOOTRAISEHEIGHT    = 1014
+SPORT_API_ID_SPEEDLEVEL         = 1015
+SPORT_API_ID_HELLO              = 1016
+SPORT_API_ID_STRETCH            = 1017
+SPORT_API_ID_TRAJECTORYFOLLOW   = 1018
+SPORT_API_ID_CONTINUOUSGAIT     = 1019
+SPORT_API_ID_CONTENT            = 1020
+SPORT_API_ID_WALLOW             = 1021
+SPORT_API_ID_DANCE1             = 1022
+SPORT_API_ID_DANCE2             = 1023
+SPORT_API_ID_GETBODYHEIGHT      = 1024
 SPORT_API_ID_GETFOOTRAISEHEIGHT = 1025
-SPORT_API_ID_GETSPEEDLEVEL = 1026
-SPORT_API_ID_SWITCHJOYSTICK = 1027
-SPORT_API_ID_POSE = 1028
-SPORT_API_ID_SCRAPE = 1029
-SPORT_API_ID_FRONTFLIP = 1030
-SPORT_API_ID_FRONTJUMP = 1031
-SPORT_API_ID_FRONTPOUNCE = 1032
-SPORT_API_ID_WIGGLEHIPS = 1033
-SPORT_API_ID_GETSTATE = 1034
-SPORT_API_ID_ECONOMICGAIT = 1035
-SPORT_API_ID_HEART = 1036
-ROBOT_SPORT_API_ID_DANCE3             = 1037
-ROBOT_SPORT_API_ID_DANCE4             = 1038
-ROBOT_SPORT_API_ID_HOPSPINLEFT        = 1039
-ROBOT_SPORT_API_ID_HOPSPINRIGHT       = 1040
+SPORT_API_ID_GETSPEEDLEVEL      = 1026
+SPORT_API_ID_SWITCHJOYSTICK     = 1027
+SPORT_API_ID_POSE               = 1028
+SPORT_API_ID_SCRAPE             = 1029
+SPORT_API_ID_FRONTFLIP          = 1030
+SPORT_API_ID_FRONTJUMP          = 1031
+SPORT_API_ID_FRONTPOUNCE        = 1032
+SPORT_API_ID_WIGGLEHIPS         = 1033
+SPORT_API_ID_GETSTATE           = 1034
+SPORT_API_ID_HEART              = 1036
 
-ROBOT_SPORT_API_ID_LEFTFLIP           = 1042
-ROBOT_SPORT_API_ID_BACKFLIP           = 1044
-ROBOT_SPORT_API_ID_FREEWALK           = 1045
-ROBOT_SPORT_API_ID_FREEBOUND          = 1046
-ROBOT_SPORT_API_ID_FREEJUMP           = 1047
-ROBOT_SPORT_API_ID_FREEAVOID          = 1048
-ROBOT_SPORT_API_ID_WALKSTAIR          = 1049
-ROBOT_SPORT_API_ID_WALKUPRIGHT        = 1050
-ROBOT_SPORT_API_ID_CROSSSTEP          = 1051
+# ------------------------------------------------------------------ #
+#  Base gaits moved to 106x in V 1.1.6                               #
+# ------------------------------------------------------------------ #
+SPORT_API_ID_STATICWALK         = 1061
+SPORT_API_ID_TROTRUN            = 1062
+SPORT_API_ID_ECONOMICGAIT       = 1063
 
-"""
-" error code
-"""
-# client side
+# Aliases with ROBOT_ prefix (needed for RegistApi calls)
+ROBOT_SPORT_API_ID_STATICWALK   = 1061
+ROBOT_SPORT_API_ID_TROTRUN      = 1062
+ROBOT_SPORT_API_ID_ECONOMICGAIT = 1063
+
+# ------------------------------------------------------------------ #
+#  Legacy flips                                                      #
+# ------------------------------------------------------------------ #
+ROBOT_SPORT_API_ID_LEFTFLIP     = 2041
+ROBOT_SPORT_API_ID_BACKFLIP     = 2043
+
+# ------------------------------------------------------------------ #
+#  V2.0 motion-switcher / AI-mode IDs                                #
+# ------------------------------------------------------------------ #
+ROBOT_SPORT_API_ID_HANDSTAND        = 2044
+ROBOT_SPORT_API_ID_FREEWALK         = 2045
+ROBOT_SPORT_API_ID_FREEBOUND        = 2046
+ROBOT_SPORT_API_ID_FREEJUMP         = 2047
+ROBOT_SPORT_API_ID_FREEAVOID        = 2048
+ROBOT_SPORT_API_ID_CLASSICWALK      = 2049
+ROBOT_SPORT_API_ID_WALKUPRIGHT      = 2050
+ROBOT_SPORT_API_ID_CROSSSTEP        = 2051
+ROBOT_SPORT_API_ID_AUTORECOVERY_SET = 2054
+ROBOT_SPORT_API_ID_AUTORECOVERY_GET = 2055
+ROBOT_SPORT_API_ID_SWITCHAVOIDMODE  = 2058
+
+# ------------------------------------------------------------------ #
+#  Error codes                                                       #
+# ------------------------------------------------------------------ #
 SPORT_ERR_CLIENT_POINT_PATH = 4101
-# server side
-SPORT_ERR_SERVER_OVERTIME = 4201
-SPORT_ERR_SERVER_NOT_INIT = 4202
+SPORT_ERR_SERVER_OVERTIME   = 4201
+SPORT_ERR_SERVER_NOT_INIT   = 4202

--- a/unitree_sdk2py/go2/sport/sport_client.py
+++ b/unitree_sdk2py/go2/sport/sport_client.py
@@ -1,19 +1,15 @@
 import json
-
 from ...rpc.client import Client
 from .sport_api import *
 
-"""
-" SPORT_PATH_POINT_SIZE
-"""
+# number of points expected by TrajectoryFollow
 SPORT_PATH_POINT_SIZE = 30
 
 
-"""
-" class PathPoint
-"""
 class PathPoint:
-    def __init__(self, timeFromStart: float, x: float, y: float, yaw: float, vx: float, vy: float, vyaw: float):
+    """Single trajectory point for TrajectoryFollow()."""
+    def __init__(self, timeFromStart: float, x: float, y: float,
+                 yaw: float, vx: float, vy: float, vyaw: float):
         self.timeFromStart = timeFromStart
         self.x = x
         self.y = y
@@ -23,424 +19,131 @@ class PathPoint:
         self.vyaw = vyaw
 
 
-"""
-" class SportClient
-"""
 class SportClient(Client):
+    """
+    Python wrapper for Unitree Go2 high-level / AI motion control (SDK ≥ V1.1.6).
+    """
+
     def __init__(self, enableLease: bool = False):
         super().__init__(SPORT_SERVICE_NAME, enableLease)
 
-
+    # --------------------------------------------------------------------- #
+    #  Init – register every API ID exactly once                            #
+    # --------------------------------------------------------------------- #
     def Init(self):
-        # set api version
         self._SetApiVerson(SPORT_API_VERSION)
-        
-        # regist api
-        self._RegistApi(SPORT_API_ID_DAMP, 0)
-        self._RegistApi(SPORT_API_ID_BALANCESTAND, 0)
-        self._RegistApi(SPORT_API_ID_STOPMOVE, 0)
-        self._RegistApi(SPORT_API_ID_STANDUP, 0)
-        self._RegistApi(SPORT_API_ID_STANDDOWN, 0)
-        self._RegistApi(SPORT_API_ID_RECOVERYSTAND, 0)
-        self._RegistApi(SPORT_API_ID_EULER, 0)
-        self._RegistApi(SPORT_API_ID_MOVE, 0)
-        self._RegistApi(SPORT_API_ID_SIT, 0)
-        self._RegistApi(SPORT_API_ID_RISESIT, 0)
-        self._RegistApi(SPORT_API_ID_SWITCHGAIT, 0)
-        self._RegistApi(SPORT_API_ID_TRIGGER, 0)
-        self._RegistApi(SPORT_API_ID_BODYHEIGHT, 0)
-        self._RegistApi(SPORT_API_ID_FOOTRAISEHEIGHT, 0)
-        self._RegistApi(SPORT_API_ID_SPEEDLEVEL, 0)
-        self._RegistApi(SPORT_API_ID_HELLO, 0)
-        self._RegistApi(SPORT_API_ID_STRETCH, 0)
-        self._RegistApi(SPORT_API_ID_TRAJECTORYFOLLOW, 0)
-        self._RegistApi(SPORT_API_ID_CONTINUOUSGAIT, 0)
-        # self._RegistApi(SPORT_API_ID_CONTENT, 0)
-        self._RegistApi(SPORT_API_ID_WALLOW, 0)
-        self._RegistApi(SPORT_API_ID_DANCE1, 0)
-        self._RegistApi(SPORT_API_ID_DANCE2, 0)
-        # self._RegistApi(SPORT_API_ID_GETBODYHEIGHT, 0)
-        # self._RegistApi(SPORT_API_ID_GETFOOTRAISEHEIGHT, 0)
-        # self._RegistApi(SPORT_API_ID_GETSPEEDLEVEL, 0)
-        self._RegistApi(SPORT_API_ID_SWITCHJOYSTICK, 0)
-        self._RegistApi(SPORT_API_ID_POSE, 0)
-        self._RegistApi(SPORT_API_ID_SCRAPE, 0)
-        self._RegistApi(SPORT_API_ID_FRONTFLIP, 0)
-        self._RegistApi(SPORT_API_ID_FRONTJUMP, 0)
-        self._RegistApi(SPORT_API_ID_FRONTPOUNCE, 0)
-        self._RegistApi(SPORT_API_ID_WIGGLEHIPS, 0)
-        self._RegistApi(SPORT_API_ID_GETSTATE, 0)
-        self._RegistApi(SPORT_API_ID_ECONOMICGAIT, 0)
-        self._RegistApi(SPORT_API_ID_HEART, 0)
 
+        # 1) legacy sport (basic posture, speed, etc.)
+        legacy_ids = [
+            SPORT_API_ID_DAMP, SPORT_API_ID_BALANCESTAND, SPORT_API_ID_STOPMOVE,
+            SPORT_API_ID_STANDUP, SPORT_API_ID_STANDDOWN, SPORT_API_ID_RECOVERYSTAND,
+            SPORT_API_ID_EULER, SPORT_API_ID_MOVE, SPORT_API_ID_SIT, SPORT_API_ID_RISESIT,
+            SPORT_API_ID_SWITCHGAIT, SPORT_API_ID_TRIGGER, SPORT_API_ID_BODYHEIGHT,
+            SPORT_API_ID_FOOTRAISEHEIGHT, SPORT_API_ID_SPEEDLEVEL, SPORT_API_ID_HELLO,
+            SPORT_API_ID_STRETCH, SPORT_API_ID_TRAJECTORYFOLLOW, SPORT_API_ID_CONTINUOUSGAIT,
+            SPORT_API_ID_WALLOW, SPORT_API_ID_DANCE1, SPORT_API_ID_DANCE2,
+            SPORT_API_ID_SWITCHJOYSTICK, SPORT_API_ID_POSE, SPORT_API_ID_SCRAPE,
+            SPORT_API_ID_FRONTFLIP, SPORT_API_ID_FRONTJUMP, SPORT_API_ID_FRONTPOUNCE,
+            SPORT_API_ID_WIGGLEHIPS, SPORT_API_ID_GETSTATE, SPORT_API_ID_ECONOMICGAIT,
+            SPORT_API_ID_HEART, SPORT_API_ID_STATICWALK, SPORT_API_ID_TROTRUN
+        ]
+        for api in legacy_ids:
+            self._RegistApi(api, 0)
+
+        # flips still exposed as “robot” IDs
         self._RegistApi(ROBOT_SPORT_API_ID_LEFTFLIP, 0)
         self._RegistApi(ROBOT_SPORT_API_ID_BACKFLIP, 0)
-        self._RegistApi(ROBOT_SPORT_API_ID_FREEWALK, 0)
-        self._RegistApi(ROBOT_SPORT_API_ID_FREEBOUND, 0)
-        self._RegistApi(ROBOT_SPORT_API_ID_FREEJUMP, 0)
-        self._RegistApi(ROBOT_SPORT_API_ID_FREEAVOID, 0)
-        self._RegistApi(ROBOT_SPORT_API_ID_WALKSTAIR, 0)
-        self._RegistApi(ROBOT_SPORT_API_ID_WALKUPRIGHT, 0)
-        self._RegistApi(ROBOT_SPORT_API_ID_CROSSSTEP, 0)
 
-    # 1001
-    def Damp(self):
-        p = {}
-        parameter = json.dumps(p)
-        code, data = self._Call(SPORT_API_ID_DAMP, parameter)
-        return code
-    
-    # 1002
-    def BalanceStand(self):
-        p = {}
-        parameter = json.dumps(p)
-        code, data = self._Call(SPORT_API_ID_BALANCESTAND, parameter)
-        return code
-    
-    # 1003
-    def StopMove(self):
-        p = {}
-        parameter = json.dumps(p)
-        code, data = self._Call(SPORT_API_ID_STOPMOVE, parameter)
-        return code
+        # 2) AI / motion-switcher IDs (V2.0)
+        switcher_ids = [
+            ROBOT_SPORT_API_ID_HANDSTAND, ROBOT_SPORT_API_ID_FREEWALK,
+            ROBOT_SPORT_API_ID_FREEBOUND, ROBOT_SPORT_API_ID_FREEJUMP,
+            ROBOT_SPORT_API_ID_FREEAVOID, ROBOT_SPORT_API_ID_CLASSICWALK,
+            ROBOT_SPORT_API_ID_WALKUPRIGHT, ROBOT_SPORT_API_ID_CROSSSTEP,
+            ROBOT_SPORT_API_ID_AUTORECOVERY_SET, ROBOT_SPORT_API_ID_AUTORECOVERY_GET,
+            ROBOT_SPORT_API_ID_SWITCHAVOIDMODE
+        ]
+        for api in switcher_ids:
+            self._RegistApi(api, 0)
 
-    # 1004
-    def StandUp(self):
-        p = {}
-        parameter = json.dumps(p)
-        code, data = self._Call(SPORT_API_ID_STANDUP, parameter)
-        return code
+    # --------------------------------------------------------------------- #
+    #  Legacy high-level wrappers                                           #
+    # --------------------------------------------------------------------- #
+    def Damp(self):               return self._Call(SPORT_API_ID_DAMP, "{}")[0]
+    def BalanceStand(self):       return self._Call(SPORT_API_ID_BALANCESTAND, "{}")[0]
+    def StopMove(self):           return self._Call(SPORT_API_ID_STOPMOVE, "{}")[0]
+    def StandUp(self):            return self._Call(SPORT_API_ID_STANDUP, "{}")[0]
+    def StandDown(self):          return self._Call(SPORT_API_ID_STANDDOWN, "{}")[0]
+    def RecoveryStand(self):      return self._Call(SPORT_API_ID_RECOVERYSTAND, "{}")[0]
 
-    # 1005
-    def StandDown(self):
-        p = {}
-        parameter = json.dumps(p)
-        code, data = self._Call(SPORT_API_ID_STANDDOWN, parameter)
-        return code
+    def Euler(self, roll, pitch, yaw):
+        return self._Call(SPORT_API_ID_EULER,
+                          json.dumps({"x": roll, "y": pitch, "z": yaw}))[0]
 
-    # 1006
-    def RecoveryStand(self):
-        p = {}
-        parameter = json.dumps(p)
-        code, data = self._Call(SPORT_API_ID_RECOVERYSTAND, parameter)
-        return code
+    def Move(self, vx, vy, vyaw):
+        return self._CallNoReply(SPORT_API_ID_MOVE,
+                                 json.dumps({"x": vx, "y": vy, "z": vyaw}))
 
-    # 1007
-    def Euler(self, roll: float, pitch: float, yaw: float):
-        p = {}
-        p["x"] = roll
-        p["y"] = pitch
-        p["z"] = yaw
-        parameter = json.dumps(p)
-        code, data = self._Call(SPORT_API_ID_EULER, parameter)
-        return code
+    def Sit(self):                return self._Call(SPORT_API_ID_SIT, "{}")[0]
+    def RiseSit(self):            return self._Call(SPORT_API_ID_RISESIT, "{}")[0]
+    def SwitchGait(self, t):      return self._Call(SPORT_API_ID_SWITCHGAIT,
+                                                    json.dumps({"data": t}))[0]
 
-    # 1008
-    def Move(self, vx: float, vy: float, vyaw: float):
-        p = {}
-        p["x"] = vx
-        p["y"] = vy
-        p["z"] = vyaw
-        parameter = json.dumps(p)
-        code = self._CallNoReply(SPORT_API_ID_MOVE, parameter)
-        return code
+    def BodyHeight(self, h):      return self._Call(SPORT_API_ID_BODYHEIGHT,
+                                                    json.dumps({"data": h}))[0]
+    def FootRaiseHeight(self, h): return self._Call(SPORT_API_ID_FOOTRAISEHEIGHT,
+                                                    json.dumps({"data": h}))[0]
+    def SpeedLevel(self, lvl):    return self._Call(SPORT_API_ID_SPEEDLEVEL,
+                                                    json.dumps({"data": lvl}))[0]
+    def Hello(self):              return self._Call(SPORT_API_ID_HELLO, "{}")[0]
+    def Stretch(self):            return self._Call(SPORT_API_ID_STRETCH, "{}")[0]
 
-    # 1009
-    def Sit(self):
-        p = {}
-        parameter = json.dumps(p)
-        code, data = self._Call(SPORT_API_ID_SIT, parameter)
-        return code
+    def ContinuousGait(self, flag):
+        return self._Call(SPORT_API_ID_CONTINUOUSGAIT,
+                          json.dumps({"data": flag}))[0]
 
-    #1010
-    def RiseSit(self):
-        p = {}
-        parameter = json.dumps(p)
-        code, data = self._Call(SPORT_API_ID_RISESIT, parameter)
-        return code
+    def EconomicGait(self, flag):
+        return self._Call(SPORT_API_ID_ECONOMICGAIT,
+                          json.dumps({"data": flag}))[0]
 
-    # 1011
-    def SwitchGait(self, t: int):
-        p = {}
-        p["data"] = t
-        parameter = json.dumps(p)
-        code, data = self._Call(SPORT_API_ID_SWITCHGAIT, parameter)
-        return code
+    # flips
+    def LeftFlip(self): return self._Call(ROBOT_SPORT_API_ID_LEFTFLIP,
+                                          json.dumps({"data": True}))[0]
+    def BackFlip(self): return self._Call(ROBOT_SPORT_API_ID_BACKFLIP,
+                                          json.dumps({"data": True}))[0]
 
-    # 1012
-    def Trigger(self):
-        p = {}
-        parameter = json.dumps(p)
-        code, data = self._Call(SPORT_API_ID_TRIGGER, parameter)
-        return code
+    # moved gaits
+    def StaticWalk(self): return self._Call(ROBOT_SPORT_API_ID_STATICWALK, "{}")[0]
+    def TrotRun(self):    return self._Call(ROBOT_SPORT_API_ID_TROTRUN, "{}")[0]
 
-    # 1013
-    def BodyHeight(self, height: float):
-        p = {}
-        p["data"] = height
-        parameter = json.dumps(p)
-        code, data = self._Call(SPORT_API_ID_BODYHEIGHT, parameter)
-        return code
+    # --------------------------------------------------------------------- #
+    #  Motion-switcher wrappers                                             #
+    # --------------------------------------------------------------------- #
+    def FreeWalk(self, f):   return self._Call(ROBOT_SPORT_API_ID_FREEWALK,
+                                               json.dumps({"data": f}))[0]
+    def FreeBound(self, f):  return self._Call(ROBOT_SPORT_API_ID_FREEBOUND,
+                                               json.dumps({"data": f}))[0]
+    def FreeJump(self, f):   return self._Call(ROBOT_SPORT_API_ID_FREEJUMP,
+                                               json.dumps({"data": f}))[0]
+    def FreeAvoid(self, f):  return self._Call(ROBOT_SPORT_API_ID_FREEAVOID,
+                                               json.dumps({"data": f}))[0]
 
-    # 1014
-    def FootRaiseHeight(self, height: float):
-        p = {}
-        p["data"] = height
-        parameter = json.dumps(p)
-        code, data = self._Call(SPORT_API_ID_FOOTRAISEHEIGHT, parameter)
-        return code
+    def HandStand(self, f):  return self._Call(ROBOT_SPORT_API_ID_HANDSTAND,
+                                               json.dumps({"data": f}))[0]
+    def WalkUpright(self, f):return self._Call(ROBOT_SPORT_API_ID_WALKUPRIGHT,
+                                               json.dumps({"data": f}))[0]
+    def CrossStep(self, f):  return self._Call(ROBOT_SPORT_API_ID_CROSSSTEP,
+                                               json.dumps({"data": f}))[0]
+    def ClassicWalk(self, f):return self._Call(ROBOT_SPORT_API_ID_CLASSICWALK,
+                                               json.dumps({"data": f}))[0]
 
-    # 1015
-    def SpeedLevel(self, level: int):
-        p = {}
-        p["data"] = level
-        parameter = json.dumps(p)
-        code, data = self._Call(SPORT_API_ID_SPEEDLEVEL, parameter)
-        return code
+    def AutoRecoverSet(self, f):
+        return self._Call(ROBOT_SPORT_API_ID_AUTORECOVERY_SET,
+                          json.dumps({"data": f}))[0]
 
-    # 1016
-    def Hello(self):
-        p = {}
-        parameter = json.dumps(p)
-        code, data = self._Call(SPORT_API_ID_HELLO, parameter)
-        return code
+    def AutoRecoverGet(self):
+        code, data = self._Call(ROBOT_SPORT_API_ID_AUTORECOVERY_GET, "{}")
+        return code, json.loads(data)["data"] if code == 0 else (code, None)
 
-    # 1017
-    def Stretch(self):
-        p = {}
-        parameter = json.dumps(p)
-        code, data = self._Call(SPORT_API_ID_STRETCH, parameter)
-        return code
-
-    # 1018
-    def TrajectoryFollow(self, path: list):
-        l = len(path)
-        if l != SPORT_PATH_POINT_SIZE:
-            return SPORT_ERR_CLIENT_POINT_PATH
-
-        path_p = []
-        for i in range(l):
-            point = path[i]
-            p = {}
-            p["t_from_start"] = point.timeFromStart
-            p["x"] = point.x
-            p["y"] = point.y
-            p["yaw"] = point.yaw
-            p["vx"] = point.vx
-            p["vy"] = point.vy
-            p["vyaw"] = point.vyaw
-            path_p.append(p)
-            
-        parameter = json.dumps(path_p)
-        code = self._CallNoReply(SPORT_API_ID_TRAJECTORYFOLLOW, parameter)
-        return code
-
-    # 1019
-    def ContinuousGait(self, flag: int):
-        p = {}
-        p["data"] = flag
-        parameter = json.dumps(p)
-        code, data = self._Call(SPORT_API_ID_CONTINUOUSGAIT, parameter)
-        return code
-
-    # # 1020
-    # def Content(self):
-    #     p = {}
-    #     parameter = json.dumps(p)
-    #     code, data = self._Call(SPORT_API_ID_CONTENT, parameter)
-    #     return code
-    
-    # 1021
-    def Wallow(self):
-        p = {}
-        parameter = json.dumps(p)
-        code, data = self._Call(SPORT_API_ID_WALLOW, parameter)
-        return code
-
-    # 1022
-    def Dance1(self):
-        p = {}
-        parameter = json.dumps(p)
-        code, data = self._Call(SPORT_API_ID_DANCE1, parameter)
-        return code
-
-    # 1023
-    def Dance2(self):
-        p = {}
-        parameter = json.dumps(p)
-        code, data = self._Call(SPORT_API_ID_DANCE2, parameter)
-        return code
-
-    # 1025
-    def GetFootRaiseHeight(self):
-        p = {}
-        parameter = json.dumps(p)
-        
-        code, data = self._Call(SPORT_API_ID_GETFOOTRAISEHEIGHT, parameter)
-        
-        if code == 0:
-            d = json.loads(data)
-            return code, d["data"]
-        else:
-            return code, None
-            
-
-    # 1026
-    def GetSpeedLevel(self):
-        p = {}
-        parameter = json.dumps(p)
-        
-        code, data = self._Call(SPORT_API_ID_GETSPEEDLEVEL, parameter)
-        
-        if code == 0:
-            d = json.loads(data)
-            return code, d["data"]
-        else:
-            return code, None
-
-    # 1027
-    def SwitchJoystick(self, on: bool):
-        p = {}
-        p["data"] = on
-        parameter = json.dumps(p)
-        code, data = self._Call(SPORT_API_ID_SWITCHJOYSTICK, parameter)
-        return code
-
-    # 1028
-    def Pose(self, flag: bool):
-        p = {}
-        p["data"] = flag
-        parameter = json.dumps(p)
-        code, data = self._Call(SPORT_API_ID_POSE, parameter)
-        return code
-
-    # 1029
-    def Scrape(self):
-        p = {}
-        parameter = json.dumps(p)
-        code, data = self._Call(SPORT_API_ID_SCRAPE, parameter)
-        return code
-
-    # 1030
-    def FrontFlip(self):
-        p = {}
-        parameter = json.dumps(p)
-        code, data = self._Call(SPORT_API_ID_FRONTFLIP, parameter)
-        return code
-
-    # 1031
-    def FrontJump(self):
-        p = {}
-        parameter = json.dumps(p)
-        code, data = self._Call(SPORT_API_ID_FRONTJUMP, parameter)
-        return code
-
-    # 1032
-    def FrontPounce(self):
-        p = {}
-        parameter = json.dumps(p)
-        code, data = self._Call(SPORT_API_ID_FRONTPOUNCE, parameter)
-        return code
-
-    # 1033
-    def WiggleHips(self):
-        p = {}
-        parameter = json.dumps(p)
-        code, data = self._Call(SPORT_API_ID_WIGGLEHIPS, parameter)
-        return code
-
-    # 1034
-    def GetState(self, keys: list):
-        parameter = json.dumps(keys)
-        code, data = self._Call(SPORT_API_ID_GETSTATE, parameter)
-        if code == 0:
-            return code, json.loads(data)
-        else:
-            return code, None
-
-    # 1035
-    def EconomicGait(self, flag: bool):
-        p = {}
-        p["data"] = flag
-        parameter = json.dumps(p)
-        code, data = self._Call(SPORT_API_ID_ECONOMICGAIT, parameter)
-        return code
-
-    # 1036
-    def Heart(self):
-        p = {}
-        parameter = json.dumps(p)
-        code, data = self._Call(SPORT_API_ID_HEART, parameter)
-        return code
-    
-    # 1042
-    def LeftFlip(self):
-        p = {}
-        p["data"] = True
-        parameter = json.dumps(p)
-        code, data = self._Call(ROBOT_SPORT_API_ID_LEFTFLIP, parameter)
-        return code
-
-    # 1044
-    def BackFlip(self):
-        p = {}
-        p["data"] = True
-        parameter = json.dumps(p)
-        code, data = self._Call(ROBOT_SPORT_API_ID_BACKFLIP, parameter)
-        return code
-
-    # 1045
-    def FreeWalk(self, flag: bool):
-        p = {}
-        p["data"] = True
-        parameter = json.dumps(p)
-        code, data = self._Call(ROBOT_SPORT_API_ID_FREEWALK, parameter)
-        return code
-
-    # 1046
-    def FreeBound(self, flag: bool):
-        p = {}
-        p["data"] = flag
-        parameter = json.dumps(p)
-        code, data = self._Call(ROBOT_SPORT_API_ID_FREEBOUND, parameter)
-        return code
-    
-    # 1047
-    def FreeJump(self, flag: bool):
-        p = {}
-        p["data"] = flag
-        parameter = json.dumps(p)
-        code, data = self._Call(ROBOT_SPORT_API_ID_FREEJUMP, parameter)
-        return code
-
-    # 1048
-    def FreeAvoid(self, flag: bool):
-        p = {}
-        p["data"] = flag
-        parameter = json.dumps(p)
-        code, data = self._Call(ROBOT_SPORT_API_ID_FREEAVOID, parameter)
-        return code
-
-    # 1049
-    def WalkStair(self, flag: bool):
-        p = {}
-        p["data"] = flag
-        parameter = json.dumps(p)
-        code, data = self._Call(ROBOT_SPORT_API_ID_WALKSTAIR, parameter)
-        return code
-    
-    # 1050
-    def WalkUpright(self, flag: bool):
-        p = {}
-        p["data"] = flag
-        parameter = json.dumps(p)
-        code, data = self._Call(ROBOT_SPORT_API_ID_WALKUPRIGHT, parameter)
-        return code
-
-    # 1051
-    def CrossStep(self, flag: bool):  
-        p = {}
-        p["data"] = flag
-        parameter = json.dumps(p)
-        code, data = self._Call(ROBOT_SPORT_API_ID_CROSSSTEP, parameter)
-        return code
+    def SwitchAvoidMode(self):
+        return self._Call(ROBOT_SPORT_API_ID_SWITCHAVOIDMODE, "{}")[0]


### PR DESCRIPTION
## Summary

This PR updates **unitree_sdk2_python** to the current high-level interface defined in the C++ headers shipped with Go2 firmware **V 1.1.6** (May 2025).  
It adds all new motion-switcher APIs, removes deprecated calls, corrects every numeric ID, and provides a clean demo script.

---

## Motivation

* The Go2 V 1.1.6 C++ API introduces new AI modes (FreeWalk, HandStand, ClassicWalk, …) and moves three base gaits to a new 106x block.  
* The published Python SDK still targets the pre-1.1.6 interface; users hit `NameError` / `3203 unknown api` on current robots.  
* Updating the SDK ensures that Python control is feature-complete and consistent with the C++ reference.

---

## Changes

| Module | Key updates |
|--------|-------------|
| **`go2/sport/sport_api.py`** | * Rebuilt constant table from `sport_api.hpp` (IDs 1001-2058).<br>* Added new V 2.0 IDs `2044‒2058` and aliases for `StaticWalk`, `TrotRun`, `EconomicGait` (`1061‒1063`). |
| **`go2/sport/sport_client.py`** | * Registers every valid ID once.<br>* Added wrappers: `HandStand`, `ClassicWalk`, `FreeBound`, `FreeJump`, `FreeAvoid`, `WalkUpright`, `CrossStep`, `StaticWalk`, `TrotRun`, `AutoRecoverSet/Get`, `SwitchAvoidMode`.<br>* Removed deprecated `WalkStair`. |
| **Example `go2_sport_client.py`** | * Interactive CLI demo covering all new commands; type `list` to show IDs. |
