### PR TITLE
Fix CYCLONEDDS_HOME path export

### DIFF
--- a/README zh.md
+++ b/README zh.md
@@ -33,7 +33,7 @@ cmake --build . --target install
 进入 unitree_sdk2_python 目录，设置 `CYCLONEDDS_HOME` 为刚刚编译好的 cyclonedds 所在路径，再安装 unitree_sdk2_python
 ```bash
 cd ~/unitree_sdk2_python
-export CYCLONEDDS_HOME="~/cyclonedds/install"
+export CYCLONEDDS_HOME=$HOME/cyclonedds/install
 pip3 install -e .
 ```
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ cmake --build . --target install
 Enter the unitree_sdk2_python directory, set `CYCLONEDDS_HOME` to the path of the cyclonedds you just compiled, and then install unitree_sdk2_python.
 ```bash
 cd ~/unitree_sdk2_python
-export CYCLONEDDS_HOME="~/cyclonedds/install"
+export CYCLONEDDS_HOME=$HOME/cyclonedds/install
 pip3 install -e .
 ```
 For details, see: https://pypi.org/project/cyclonedds/#installing-with-pre-built-binaries


### PR DESCRIPTION
Replaced export CYCLONEDDS_HOME="~/cyclonedds/install" with
export CYCLONEDDS_HOME=$HOME/cyclonedds/install on README.md

The tilde (~) is not expanded by export when quoted, which causes the variable to point to the literal string ~/cyclonedds/install instead of the user’s home directory. Using $HOME ensures the path resolves correctly across shells.