### PR TITLE
Add init.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,9 @@ setup(name='unitree_sdk2py',
       long_description_content_type="text/markdown",
       license="BSD-3-Clause",
       packages=find_packages(include=['unitree_sdk2py','unitree_sdk2py.*']),
+      package_data={
+          'unitree_sdk2py': ['utils/lib/*.so'],
+      },
       description='Unitree robot sdk version 2 for python',
       project_urls={
             "Source Code": "https://github.com/unitreerobotics/unitree_sdk2_python",


### PR DESCRIPTION
Hi, I am using Pixi to install this repo here as a dependency. However, while the install is successful, several modules are missing, e.g., when I run
`ls -la .pixi/envs/default/lib/python3.10/site-packages/unitree_sdk2py/`
modules such as `b2` etc are missing. The reason is that these directories do not contain `__init__.py`. 

Looking at the `master` branch, I'm not sure why you have `__init__.py` inside `go2` but not the other subdirectories. This PR creates the missing `__init__.py` files.