### PR TITLE
Relax cyclonedds pin: 0.10.2 Domain creation hangs on modern kernels

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(name='unitree_sdk2py',
       },
       python_requires='>=3.8',
       install_requires=[
-            "cyclonedds==0.10.2",
+            "cyclonedds>=0.10.2,<12",
             "numpy",
             "opencv-python",
       ],


### PR DESCRIPTION
On recent Linux kernels (observed: Ubuntu 24.04, kernel 6.17), the pinned `cyclonedds==0.10.2` wheel's `Domain` creation blocks indefinitely **when using the auto-determine config path** — i.e. `ChannelFactoryInitialize(id)` with no `networkInterface` argument, or a bare `cyclonedds.domain.Domain(id)`. Initialization with an explicit interface (`ChannelFactoryInitialize(0, "lo")`) is unaffected.

The SDK works against cyclonedds 11.x — verified `Domain` creation, `ChannelFactoryInitialize` with and without an explicit interface, and pub/sub on `rt/lowstate` / `rt/lowcmd`, on Python 3.10 and 3.12. This relaxes the pin to `>=0.10.2,<12` so default-path users on modern kernels resolve a working wheel, while older environments keep resolving 0.10.x.

One interop note for reviewers: cyclonedds 0.10.x and 11.x participants do **not** discover each other on a multicast-incapable loopback interface (relevant for sim setups where another process in the system still runs 0.10.x, e.g. alongside the C/C++ SDK's bundled libddsc). Mixed-version deployments on `lo` should keep all participants on the same major version.

(`ChannelFactory.Init`'s `__initialized` guard already makes double-init safe on cyclonedds ≥ 11, where re-creating a live domain raises — that part is already handled on current `master`.)