### PR TITLE
fix: resolve CycloneDDS log path to current user home dir

### DIFF
--- a/unitree_sdk2py/core/channel_config.py
+++ b/unitree_sdk2py/core/channel_config.py
@@ -1,4 +1,7 @@
-ChannelConfigHasInterface = '''<?xml version="1.0" encoding="UTF-8" ?>
+import os
+_CDDS_LOG = os.path.join(os.path.expanduser("~"), "cdds.LOG")
+
+ChannelConfigHasInterface = f'''<?xml version="1.0" encoding="UTF-8" ?>
     <CycloneDDS>
         <Domain Id="any">
             <General>
@@ -8,7 +11,7 @@ ChannelConfigHasInterface = '''<?xml version="1.0" encoding="UTF-8" ?>
             </General>
             <Tracing>
                 <Verbosity>config</Verbosity>
-            <OutputFile>/tmp/cdds.LOG</OutputFile>
+            <OutputFile>{_CDDS_LOG}</OutputFile>
         </Tracing>
         </Domain>
     </CycloneDDS>'''


### PR DESCRIPTION
/tmp/cdds.LOG is shared across all users on a machine, causing log collisions in multi-developer setups. Use os.path.expanduser("~") so each user gets their own ~/cdds.LOG at import time.