### PR TITLE
Add build/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ __pycache__
 
 # python
 dist/
+build/


### PR DESCRIPTION
setuptools generates a build/ directory when installing the package in editable mode (pip install -e .), which was missing from the ignore list alongside the existing dist/ entry.