### PR TITLE
fix(package): include CRC shared libraries in builds

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include unitree_sdk2py/utils/lib *.so

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,9 @@ setup(name='unitree_sdk2py',
       long_description_content_type="text/markdown",
       license="BSD-3-Clause",
       packages=find_packages(include=['unitree_sdk2py','unitree_sdk2py.*']),
+      package_data={
+            'unitree_sdk2py.utils': ['lib/*.so'],
+      },
       description='Unitree robot sdk version 2 for python',
       project_urls={
             "Source Code": "https://github.com/unitreerobotics/unitree_sdk2_python",


### PR DESCRIPTION
### Background
The build/install artifact does not include `unitree_sdk2py/utils/lib/*.so`, which can cause CRC-related functionality to fail after installation because the shared libraries are missing.

### Changes
- Added `MANIFEST.in` to include `unitree_sdk2py/utils/lib/*.so` in the source distribution
- Added `package_data` in `setup.py` so the wheel also contains these shared libraries

### Impact
This only affects packaging output. No runtime business logic was changed.

### Verification
- Build the sdist and wheel
- Install the package and confirm the `.so` files are present under `unitree_sdk2py/utils/lib/`